### PR TITLE
Basic om docs

### DIFF
--- a/docs/before/analysis.md
+++ b/docs/before/analysis.md
@@ -29,7 +29,7 @@ The `eLog` provides a unifying entrypoint from your browser.
 | *__LCLS Data Analysis.__ TBD.* |
 
 
-Below is a brief summary of each of the major available options. Consider reading through the alternatives below to decide on which may be most appropriate for your experiment. Additional information for setting up and running each type of application can be found on their respective pages. Please note that not all applications can be run at simulatenously - potential conflicts will be highlighted in red below.
+Below is a brief summary of each of the major available options. Consider reading through the alternatives below to decide on which may be most appropriate for your experiment. Additional information for setting up and running each type of application can be found on their respective pages. Please note that not all applications can be run simultaneously - potential conflicts will be highlighted in red below.
 
 ### `psana`: the core of LCLS data analysis {: #psana}
 *in construction; contributions welcome*

--- a/docs/before/analysis.md
+++ b/docs/before/analysis.md
@@ -1,6 +1,7 @@
 !!! note "Quicklink"
     - **btx** - [btx Github repository][1]
     - **documentation** - [btx code documentation][2]
+    - **OM** - [Official documentation][3]
 
 # Routine beamtime analysis
 
@@ -18,15 +19,17 @@
 - [`smalldata`](#smalldata)
 - [`btx`](#btx)
 
-LCLS offers several tools to help you analyze your experimental data. 
-The chart below attempts at articulating them based on whether they are more generic tools like `psana` or more experiment specific like `OM` 
-and whether they are mostly used for live analysis during beamtimes like `AMI` or for slightly delayed feedback or even offline like `smalldata` and `btx`. 
+LCLS offers several tools to help you analyze your experimental data.
+The chart below attempts at articulating them based on whether they are more generic tools like `psana` or more experiment specific like `OM`
+and whether they are mostly used for live analysis during beamtimes like `AMI` or for slightly delayed feedback or even offline like `smalldata` and `btx`.
 The `eLog` provides a unifying entrypoint from your browser.
 
-| ![Data Analysis Tools](images/data_analysis_tools.png) | 
-|:--:| 
+| ![Data Analysis Tools](images/data_analysis_tools.png) |
+|:--:|
 | *__LCLS Data Analysis.__ TBD.* |
 
+
+Below is a brief summary of each of the major available options. Consider reading through the alternatives below to decide on which may be most appropriate for your experiment. Additional information for setting up and running each type of application can be found on their respective pages. Please note that not all applications can be run at simulatenously - potential conflicts will be highlighted in red below.
 
 ### `psana`: the core of LCLS data analysis {: #psana}
 *in construction; contributions welcome*
@@ -39,7 +42,17 @@ The `eLog` provides a unifying entrypoint from your browser.
 [*(back to top)*](#toc)
 
 ### `OM`: dedicated tools for online data analysis {: #om}
-*in construction; contributions welcome*
+[OM][3] (external link) is a tool and framework for monitoring experiments in real time. It can be adapted to fit a variety of experiment types, broadly applicable to any measurement involving image data; however, it is most often used for serial femtosecond crystallography (and bioSAXS), experiments for which standard programs are already bundled in the package. OM is particularly well suited to real-time feedback for PCS (protein crystal screening) experiments at LCLS.
+
+Running OM is a two-step process:
+
+1. First a monitor process is launched. The monitor collects data in real time and generally applies some sort of analysis, such as peak finding, azimuthal integration, etc. This process must be run on a machine with access to the data. At LCLS this means using the monitoring nodes (see note below).
+2. Graphical frontends are launched. These may vary by experiment, but will generally be used for viewing detector images, detected hits, and parameter tuning.
+
+For information on running OM at LCLS, please refer to the following [page](/during/om/).
+
+!!! danger "OM, shared memory, and competing processes"
+    There is a a limit to the number of additional real-time monitoring tools which can be run simultaneously with OM. Each hutch is equipped with a number of monitoring nodes which are used for real-time monitoring applications. These nodes receive a fraction of data coming from all detectors. This data is copied into shared memory to be accessed by real-time software. In general, if OM is monitoring the data, another application, such as `ami2` cannot be used at the same time.
 
 [*(back to top)*](#toc)
 
@@ -50,8 +63,8 @@ The `eLog` provides a unifying entrypoint from your browser.
 
 ### `btx`: library and workflow manager {: #btx}
 
-`btx` is a resource for analyzing experiments performed at LCLS, both during and after beamtime. 
-To facilitate rapid analysis, common data processing steps have been organized into tasks that can be easily accessed from the eLog or command-line without users having to write new code. 
+`btx` is a resource for analyzing experiments performed at LCLS, both during and after beamtime.
+To facilitate rapid analysis, common data processing steps have been organized into tasks that can be easily accessed from the eLog or command-line without users having to write new code.
 This is a primarily Python-based package to which contributions are welcome, as `btx` is intended as a library to serve the user community at LCLS. Currently most tasks are geared toward SFX data analysis, but we intend to expand the scope to encompass other experiments, such as SPI and SAXS/WAXS.
 
 !!! note "Important concepts"
@@ -135,7 +148,7 @@ If running this from the psana cluster, the following arguments should be added 
 | -e    | Name of the experiment.                             | -e <experiment_name\> |
 | -r    | Run to process. If supplied override YAML value.    | -r <run_number\>      |
 
-A related executable, `submit_range_run.sh`, will launch the same task across a series of runs. This script can be run in the same fashion as `elog_submit.sh` and with the same flags, except an additional `-s` flag should be added that determines the last run number to process. 
+A related executable, `submit_range_run.sh`, will launch the same task across a series of runs. This script can be run in the same fashion as `elog_submit.sh` and with the same flags, except an additional `-s` flag should be added that determines the last run number to process.
 
 More details about available tasks can be found in the relevant experiment pages.
 
@@ -143,14 +156,14 @@ More details about available tasks can be found in the relevant experiment pages
 ##### Chaining tasks: launching workflows from the eLog
 
 The figure below illustrates an example of how tasks can be chained as workflows, which can be triggered from the eLog to be executed at S3DF with results displayed back in the eLog.
-In your browser, you can access your {experiment} logbook (eLog) at the following URL: [https://pswww.slac.stanford.edu/lgbk/lgbk/{experiment}](). 
+In your browser, you can access your {experiment} logbook (eLog) at the following URL: [https://pswww.slac.stanford.edu/lgbk/lgbk/{experiment}]().
 
-| ![btx worfklow](images/btx_sfx_workflow.png) | 
-|:--:| 
+| ![btx worfklow](images/btx_sfx_workflow.png) |
+|:--:|
 | *__Example of SFX workflow implemented with `btx`.__ 1) Define the Airflow workflow within `btx`, eventually making use of `tppwrw` to deploy containers. 2) Setup the workflows in the eLog. 3) Trigger the workflows manually or automatically from the eLog. 4) Check the results interactively in the eLog Summary panel.* |
 
 ###### Setup the workflow definition in the eLog
-Navigate to the "Workflow definition" tab [https://pswww.slac.stanford.edu/lgbk/lgbk/{experiment}/#lcls_wf_defs]() (see step 2 in the figure above) and click on the "+" button located at the top right of the window. 
+Navigate to the "Workflow definition" tab [https://pswww.slac.stanford.edu/lgbk/lgbk/{experiment}/#lcls_wf_defs]() (see step 2 in the figure above) and click on the "+" button located at the top right of the window.
 Enter the following information:
 
 - *Name*: the memorable name you wish to call this workflow.
@@ -169,25 +182,26 @@ Enter the following information:
 
 
 ###### Trigger the workflow from the eLog
-Navigate to the "Workflow control" tab [https://pswww.slac.stanford.edu/lgbk/lgbk/{experiment}/#lcls_wf_jobs]() (see step 3 in the figure above). To trigger a worflow for a given run, select the workflow "Name" from the list in the "Job" column. 
+Navigate to the "Workflow control" tab [https://pswww.slac.stanford.edu/lgbk/lgbk/{experiment}/#lcls_wf_jobs]() (see step 3 in the figure above). To trigger a worflow for a given run, select the workflow "Name" from the list in the "Job" column.
 To trigger it for multiple consecutive runs, click on the train icon at the top right of the window, select your workflow "Name", and enter the first and last run numbers to be processed.
 
 ###### Monitor the workflow results from the eLog
-Navigate to the "Summaries" tab [https://pswww.slac.stanford.edu/lgbk/lgbk/{experiment}/#summaries]() (See step 4 in the figure above). 
+Navigate to the "Summaries" tab [https://pswww.slac.stanford.edu/lgbk/lgbk/{experiment}/#summaries]() (See step 4 in the figure above).
 In the navigation bar on the left of the window, you should see a list of "samples" and "runs". Click on them to display the results associated with the corresponding "sample" or "run".
 
 #### Contributing to the code
 
-The repository can be cloned from this [Github link](https://github.com/lcls-users/btx). The `README.md` describes guidelines for contributing to the code. 
+The repository can be cloned from this [Github link](https://github.com/lcls-users/btx). The `README.md` describes guidelines for contributing to the code.
 
 - Contributing a new task
-:    New tasks should be added as separate functions to [tasks.py](https://github.com/lcls-users/btx/blob/main/scripts/tasks.py) and then can be run from the command-line as described above. 
+:    New tasks should be added as separate functions to [tasks.py](https://github.com/lcls-users/btx/blob/main/scripts/tasks.py) and then can be run from the command-line as described above.
 
-- Contributing new workflows 
+- Contributing new workflows
 :    To create a new workflow, make sure the tasks you wish to chain in the DAG exist. Then create a new file in the `dags/` subfolder of `btx` (get some inspiration from the [existing ones](https://github.com/lcls-users/btx/tree/main/dags)). The DAG will be available shortly after your PR has been merged in the main `btx` branch.
 
 [1]: https://github.com/lcls-users/btx
 [2]: https://lcls-users.github.io/btx/
+[3]: https://www.ondamonitor.com/html/index.html
 
 [*(back to top)*](#toc)
 

--- a/docs/during/om.md
+++ b/docs/during/om.md
@@ -1,0 +1,49 @@
+!!! note "Quicklink"
+    - **OM** - [Official documentation][1]
+
+# OM - Realtime Experiment Monitoring {: #top}
+
+---
+## Running OM {: #lcls}
+
+!!! note "Instructions may change"
+    The instructions below are valid as of LCLS Run 22 (first half of calendar year 2024). Some details of the setup may change slightly in the near future. Refer back to this page at the beginning of each run for potential updates.
+
+### Prepare workspace {: #prepare_workspace}
+At the beginning of your first shift you need to prepare OM's working directory. This requires access to the operator account for the hutch you will be running the experiment at (`mfxopr`, `cxiopr`, ...). The instructions below will be done from the perspective of `mfxopr`. You may need to subsitute the correct operator or machine names for your hutch to run the commands. The full set of commands without explanatory text can be copied at the end of this block - names will still need to be edited.
+
+!!! note "Skip Ahead"
+    If OM was requested ahead of time it is possible that these steps would have been followed by beamline staff or a member of the data systems team. In this case you can skip directly to [launching OM](#launch_om) below. Note that it may still be a good idea to update geometry or mask files.
+
+1. SSH into `mfx-monitor` with the operator account: `ssh mfxopr@mfx-monitor`. If you are using a terminal on a hutch control room machine you can simply use: `ssh mfx-monitor`
+    - If you are not using a hutch machine you may need to do this in two steps. Note you must have special permission to login as `mfxopr`. If you do not, please use a control room terminal.
+        1. `ssh mfx-monitor`
+        2. `ssh mfxopr@mfx-monitor`
+    - `mfx-monitor` is the default machine for launching OM; however, confirm with beamline staff if it is preferable to use `mfx-daq`.
+2. Move to the OM directory: `cd ~mfxopr/OM-GUI`
+3. Prepare the working directory by copying the template - replace replace `<exp_name>` with your experiment name, e.g. `mfxx1001122`:
+    - `cp -r template_2023 <exp_name>`
+4. Change to the workspace directory. If using an `ePix10k2M` detector use `<exp_name>/om-workspace`. If using a `Rayonix` detector use `<exp_name>/om-workspace-rayonix`
+     - `cd om-workspace[-rayonix]`
+5. There is a geometry (`.geom`) and a mask (`.h5`) file in this workspace directory. Update these files to the most recent versions. Ask beamline staff for where that may be located. If you need to perform any conversions see notes at the bottom of this [page](#gotchas).
+     - `cp <new_geom>.geom epix10k2M.geom # Copy new geometry to replace epix10k2M.geom or rayonix.geom`
+     - `cp <new_mask>.h5 epix10k2M.h5 # Copy new mask to replace epix10k2M.h5 or rayonix.h5`
+6. Modify the `run_om.sh` script in your workspace directory to use the proper machines for OM to run on.
+     - By default, OM will use `daq-mfx-mon02`, `daq-mfx-mon03`, `daq-mfx-mon04`, and `daq-mfx-mon05` to run on. Confirm with beamline staff that this is okay. Check where other things are running. Use `wherepsana -d` to see machines.
+     - If you need to change the machines, modify the very last line of the script: `--host daq-mfx-mon02,daq-mfx-mon03,daq-mfx-mon04,daq-mfx-mon05 $(pwd)/monitor_wrapper.sh`. **Note: There is no space between the commas and the hostnames.**
+### Launching OM {: #launch_om}
+
+
+
+## Potential Issues {: #gotchas}
+### Geometry
+Geometry conventions lead to no shortage of potential issues at LCLS. Please pay careful attention to the formats you are using with OM.
+!!! danger "Converting geometries"
+    If you need to create a new mask be aware that OM and `psana` use different formats and conventions. In order to convert a `psana` mask into an OM mask first:
+
+    1. Flatten the first coordinate of the array. E.g. An array of shape `8x16x16` becomes an array of shape `128x16`.
+    2. For OM, a value of 1 is a pixel which we want to keep, and a value of 0 is a pixel we want to mask.
+
+[1]: https://www.ondamonitor.com/html/index.html
+
+[*(back to top)*](#top)

--- a/docs/during/om.md
+++ b/docs/during/om.md
@@ -10,6 +10,9 @@
     The instructions below are valid as of LCLS Run 22 (first half of calendar year 2024). Some details of the setup may change slightly in the near future. Refer back to this page at the beginning of each run for potential updates.
 
 ### Prepare workspace {: #prepare_workspace}
+
+(This section should take no more than 5-10 minutes)
+
 At the beginning of your first shift you need to prepare OM's working directory. This requires access to the operator account for the hutch you will be running the experiment at (`mfxopr`, `cxiopr`, ...). The instructions below will be done from the perspective of `mfxopr`. You may need to subsitute the correct operator or machine names for your hutch to run the commands. The full set of commands without explanatory text can be copied at the end of this block - names will still need to be edited.
 
 !!! note "Skip Ahead"
@@ -31,9 +34,46 @@ At the beginning of your first shift you need to prepare OM's working directory.
 6. Modify the `run_om.sh` script in your workspace directory to use the proper machines for OM to run on.
      - By default, OM will use `daq-mfx-mon02`, `daq-mfx-mon03`, `daq-mfx-mon04`, and `daq-mfx-mon05` to run on. Confirm with beamline staff that this is okay. Check where other things are running. Use `wherepsana -d` to see machines.
      - If you need to change the machines, modify the very last line of the script: `--host daq-mfx-mon02,daq-mfx-mon03,daq-mfx-mon04,daq-mfx-mon05 $(pwd)/monitor_wrapper.sh`. **Note: There is no space between the commas and the hostnames.**
+
+<details>
+    <summary> Combined commands </summary>
+SSH to appropriate machine as operator
+
+```bash
+ssh mfxopr@mfx-monitor # if on control room terminal simply ssh mfx-monitor
+# If the above doesn't work, try it in two steps
+# ssh mfx-monitor
+# ssh mfxopr@mfx-monitor
+```
+
+Setup the working directory - example for `rayonix` detector. Fill in `EXPNAME` where appropriate. Ask beamline staff for the locations of geometry files and masks.
+
+```bash
+cd ~mfxopr/OM-GUI
+EXP_NAME=MYEXP1234 # REPLACE with experiment name
+cp -r template_2023 $EXP_NAME
+cd om-workspace-rayonix
+cp <geom_file_location> rayonix.geom
+cp <mask_file_location> rayonix.h5
+nano run_om.sh # Double check the last line for appropriate machines.
+```
+</details>
+
 ### Launching OM {: #launch_om}
+Once the folder has been appropriately setup, there are a number of processes which need to be launched.
 
-
+1. SSH back to the appropriate machine. As above, this is usually `mfx-monitor`; however, it may be `mfx-daq` depending on what the beamline staff say.
+2. Launch the monitor process: `screen ~mfxopr/OM-GUI/<exp_name>/om-workspace[-rayonix]/run_om.sh`
+    - The use of `screen` is preferred. This will allow other people to reattach to the session from another terminal to e.g. restart the monitor if there are any issues.
+    - To reattach to the session use `screen -xr`. Do **NOT** use `-dr` -> This will detach all clients.
+3. Launch the main GUI elements:
+    - Main GUI: `./~mfxopr/OM-GUI/<exp_name>/om-workspace[-rayonix]/run_gui.sh`
+    - Frame Viewer: `./~mfxopr/OM-GUI/<exp_name>/om-workspace[-rayonix]/run_frame_viewer.sh`
+4. Optionally, start the parameter tweaker. This is only recommended for advanced users with extensive experience with the algorithm and the meaning of relevant parameters.
+    - `./~mfxopr/OM-GUI/<exp_name>/om-workspace[-rayonix]/run_parameter_tweaker.sh`
+    - Note, making modifications using the GUI interface of the parameter tweaker will NOT update the monitor process.
+    - To update the parameters, after a more optimal set has been found using the GUI interface, copy the parameters into the appropriate locations in the `monitor.yaml` file. This is located in the same directory as all the other scripts to launch OM components. The monitor process must be restarted.
+---
 
 ## Potential Issues {: #gotchas}
 ### Geometry

--- a/docs/during/om.md
+++ b/docs/during/om.md
@@ -24,7 +24,7 @@ At the beginning of your first shift you need to prepare OM's working directory.
         2. `ssh mfxopr@mfx-monitor`
     - `mfx-monitor` is the default machine for launching OM; however, confirm with beamline staff if it is preferable to use `mfx-daq`.
 2. Move to the OM directory: `cd ~mfxopr/OM-GUI`
-3. Prepare the working directory by copying the template - replace replace `<exp_name>` with your experiment name, e.g. `mfxx1001122`:
+3. Prepare the working directory by copying the template - replace `<exp_name>` with your experiment name, e.g. `mfxx1001122`:
     - `cp -r template_2023 <exp_name>`
 4. Change to the workspace directory. If using an `ePix10k2M` detector use `<exp_name>/om-workspace`. If using a `Rayonix` detector use `<exp_name>/om-workspace-rayonix`
      - `cd om-workspace[-rayonix]`
@@ -77,7 +77,7 @@ Once the folder has been appropriately setup, there are a number of processes wh
 
 ## Potential Issues {: #gotchas}
 ### Geometry
-Geometry conventions lead to no shortage of potential issues at LCLS. Please pay careful attention to the formats you are using with OM.
+Geometry conventions lead to no shortage of potential issues at LCLS. Please pay careful attention to the formats you are using with OM. OM expects the `.geom` geometry file to follow Crystfel's format which is different from the `psana` format for geometry files.
 !!! danger "Converting geometries"
     If you need to create a new mask be aware that OM and `psana` use different formats and conventions. In order to convert a `psana` mask into an OM mask first:
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -12,6 +12,7 @@ nav:
         - Computing Accounts and Resources: 'before/accounts.md'
         - Routine beamtime analysis: 'before/analysis.md'
     - During your experiment:
+        - Running OM: 'during/om.md'
         - Running the timetool: 'during/timetool.md'
     - After your experiment:
         - Reanalyzing timing data: 'after/timetool.md'


### PR DESCRIPTION
This PR provides:
- A basic blurb for the `OM` software/framework.
- A new page explaining how to setup `OM` by copying a template folder. This is a recommended method as of LCLS run 22 (this calendar year, 2024).
- Minor formatting changes and the appropriate modification of the navigation bar.