### PR TITLE
Update README for Relative Links

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,3 +17,10 @@ $ mkdocs serve
 ```
 
 By default the website is served over port 8000 and can be accessed from your browser via ```localhost:8000``` (```http://127.0.0.1:8000```).
+
+# A note on relative links
+Due to how the site is built and documents are linked, only true relative links can be used when linking between internal pages. I.e. if you want to link to another page on the website, use a relative path and include the extension of the file you would like to link to. This is instead of using the intended output destination as you may be accustomed to. For example, if you are working on a page that resides in the `before` directory, and would like to link to another page, `other_page.md`, you can do so like:
+- `[other page link](other_page.md)`, if the other page is also in the `before` directory. 
+- Or, `[other page link](../during/other_page.md)` if it is in another directory, such as `during`. 
+
+This will allow the links to properly resolve. Links of this format: `[other page link](/before/other_page/)` will NOT work properly when the website is published.


### PR DESCRIPTION
Change Log
------------------
- Add a note to the README about using proper relative links to to link to internal pages on the published website. Using the intended output destination does not work when the website is published to `Read the Docs`.